### PR TITLE
Remove Assets namespace

### DIFF
--- a/Editor/Analytics/DTDPostProcessAnalytics.cs
+++ b/Editor/Analytics/DTDPostProcessAnalytics.cs
@@ -5,7 +5,7 @@ using UnityEditor;
 using UnityEditor.Callbacks;
 using UnityEngine;
 
-namespace Assets.DevToDev.Analytics.Editor
+namespace DevToDev.Analytics.Editor
 {
     public static class DTDPostProcessAnalytics
     {


### PR DESCRIPTION
This package simply takes that name without even using it. We have a large-scale framework, divided into several packages, used in many projects, which also uses the name “Assets”, but for its intended purpose.