### PR TITLE
Wrapped UnityEditor.iOS.Xcode using statements in #if UNITY_IOS.

### DIFF
--- a/Editor/Analytics/DTDPostProcessAnalytics.cs
+++ b/Editor/Analytics/DTDPostProcessAnalytics.cs
@@ -4,8 +4,10 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using UnityEditor;
 using UnityEditor.Callbacks;
+#if UNITY_IOS
 using UnityEditor.iOS.Xcode;
 using UnityEditor.iOS.Xcode.Extensions;
+#endif
 using UnityEngine;
 
 namespace DevToDev.Analytics.Editor


### PR DESCRIPTION
This will allow developers who don't have Unity iOS build support installed to use the package.